### PR TITLE
Specifies mermaid version for the mermaid client has been removed from the current mermaid version (v7.1.0).

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Individual Classes
 
     Mermaid
 
-        sudo nmp install mermaid
+        sudo npm install -g mermaid@7.0.6
         https://knsv.github.io/mermaid (needs phantomjs)
         
         Runs mermaid -o <basedir> [options] <fname>.mermaid

--- a/README.rst
+++ b/README.rst
@@ -375,7 +375,7 @@ Individual Classes
 
     Mermaid
 
-        sudo nmp install mermaid
+        sudo npm install -g mermaid@7.0.6
         https://knsv.github.io/mermaid (needs phantomjs)
         
         Runs mermaid -o <basedir> [options] <fname>.mermaid


### PR DESCRIPTION
Well, it takes me a lot of time to find out what is wrong with my mermaid, and I found out that mermaid CLI has been removed from main project. Installing mermaid v7.0.6 works for me.